### PR TITLE
Adds linters that disallow walrus usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ with open('file.txt') as f:
 
 Please read the [PEP 572](https://www.python.org/dev/peps/pep-0572/) for more information about what is valid/invalid.
 
+# Limiting Walrus Operator Usage
+
+In case you are not a big fan of this feature - you can always discourage its usage with linters:
+
+- [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) - the strictest Python linter out there.
+- [flake8-walrus](https://github.com/asottile/flake8-walrus) - flake8 plugin to do just that.
+
 # How to contribute
 
 To add a use case, please create an issue with the *Propose a Use Case* template. It would be discussed and added.


### PR DESCRIPTION
This feature is very debatable. So, I guess it is a good idea to give a reader a choice.
When to use and when not to use this feature.

So, I have added a link to https://github.com/wemake-services/wemake-python-styleguide
that forbid to use walrus and several other new features.

There's also a simple plugin for flake8 https://github.com/asottile/flake8-walrus
for ones that just want this one thing.