### PR TITLE
Fix example to have equal result

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ filtered_data = [y for x in data if (y := f(x)) is not None]
 ```
 *Instead of*
 ```python
-filtered_data = list(filter(lambda y: f(y), data))
+filtered_data = list(filter(lambda y: y is not None, map(f, data)))
 ```
 
 # Warning


### PR DESCRIPTION
The walrus example, in addition to filtering, uses the result of the function as the output value in result list. But in example without walrus operator in result list used original values.